### PR TITLE
fix(skills): проектный скил побеждает имя, команды невключённых плагинов не показываются

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,11 @@ CURSOR_API_KEY=crsr_your_key_here
 
 ## Скилы Claude Code
 
-Скилы — команды (`/skill-name`) из `~/.claude/commands/`, `~/.claude/skills/` и плагинов Claude Code. Доступны для всех провайдеров с `supports_skills=True`.
+Скилы — команды (`/skill-name`) из `~/.claude/commands/`, `~/.claude/skills/`, из `.claude/` самого проекта и из плагинов Claude Code. Доступны для всех провайдеров с `supports_skills=True`.
+
+**Что попадает в список.** Плагин показывается, только если он включён в Claude Code (`enabledPlugins` в `~/.claude/settings.json`, `~/.claude.json` или в `.claude/settings.json` проекта). Одного добавленного маркетплейса мало: его клон приезжает на диск целиком, но ни одну из этих команд Claude Code не выполнит, значит и предлагать их нечестно.
+
+**Кто выигрывает имя.** Порядок разрешения — `local` (`.claude/` рабочей директории) → `user` (`~/.claude/`) → `plugin`: специфичное побеждает общее. Источник виден в списке (📁 в боте, метка справа в Web UI), так что совпадение имён заметно человеку, а не только в коде.
 
 ### Web UI
 

--- a/promptpilot/bot.py
+++ b/promptpilot/bot.py
@@ -2279,11 +2279,25 @@ def _priority_keyboard():
     ])
 
 
+def _skill_source_mark(source: str) -> str:
+    """Where a skill comes from, in one MarkdownV2 chunk.
+
+    Two skills can share a name across a project, ~/.claude and a plugin; the
+    list must say which one a tap would actually run, or a collision looks like
+    the skill having quietly changed its description.
+    """
+    if source == "local":
+        return " 📁"
+    if source.startswith("plugin:"):
+        return f" _{_esc(source)}_"
+    return ""
+
+
 def _build_skills_message(skills: list, title: str, show_proj_btn: bool = False):
     """Return (text, InlineKeyboardMarkup) for a skills list."""
     lines = [f"*{_esc(title)}*\n"]
     for s in skills:
-        local_mark = " 📁" if s.get("source") == "local" else ""
+        local_mark = _skill_source_mark(s.get("source") or "")
         hint = f" `[{_esc_code(s['argument_hint'])}]`" if s.get("argument_hint") else ""
         desc = f" — {_esc(s['description'])}" if s.get("description") else ""
         lines.append(f"`/{_esc_code(s['name'])}`{local_mark}{hint}{desc}")
@@ -2320,7 +2334,8 @@ async def cmd_skills(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not skills:
         await update.message.reply_text(
             "Скилы не найдены\\. Добавьте команды в `~/\\.claude/commands/` "
-            "или установите плагины через Claude Code\\.",
+            "или включите плагин через Claude Code \\(`/plugin`\\)\\.\n"
+            "Команды невключённых плагинов в списке не показываются\\.",
             parse_mode="MarkdownV2",
             reply_markup=_main_menu(),
         )

--- a/promptpilot/config.py
+++ b/promptpilot/config.py
@@ -796,12 +796,91 @@ def _parse_frontmatter(path: Path) -> dict:
     return result
 
 
+def _read_json_file(path: Path) -> dict:
+    """Parse a JSON config file; anything unreadable reads as {}.
+
+    These are Claude Code's own files, hand-edited and not ours to validate:
+    a stray comma in settings.json must not take the whole skills list down.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _enabled_plugins(working_dir: str = None) -> dict:
+    """Claude Code's plugin on/off state: {"<plugin>@<marketplace>": bool}.
+
+    What lies on disk under ~/.claude/plugins/marketplaces is the marketplace
+    CATALOGUE — adding a marketplace clones every plugin it offers, enabled or
+    not. What the user actually turned on is `enabledPlugins` in the settings
+    files, keyed `<plugin>@<marketplace>` (bare `<plugin>` in older versions).
+    No key anywhere means nothing is enabled, which is exactly the state after
+    merely adding a marketplace.
+
+    Read in Claude Code's own precedence order, the more specific file last.
+    """
+    files = [
+        Path.home() / ".claude" / "settings.json",
+        Path.home() / ".claude" / "settings.local.json",
+        Path.home() / ".claude.json",
+    ]
+    if working_dir:
+        files.append(Path(working_dir) / ".claude" / "settings.json")
+        files.append(Path(working_dir) / ".claude" / "settings.local.json")
+
+    state = {}
+    for path in files:
+        data = _read_json_file(path)
+        sections = [data.get("enabledPlugins")]
+        # ~/.claude.json keeps per-project settings in a "projects" map
+        projects = data.get("projects")
+        if working_dir and isinstance(projects, dict):
+            entry = projects.get(str(working_dir))
+            if isinstance(entry, dict):
+                sections.append(entry.get("enabledPlugins"))
+        for section in sections:
+            if isinstance(section, dict):
+                for key, value in section.items():
+                    state[str(key)] = bool(value)
+    return state
+
+
+def _plugin_enabled(state: dict, name: str, marketplace: str) -> bool:
+    """Is this plugin enabled, given the `enabledPlugins` state?"""
+    if marketplace and f"{name}@{marketplace}" in state:
+        return state[f"{name}@{marketplace}"]
+    if name in state:
+        return state[name]
+    # Marketplace not derivable from the path (a layout we don't know): accept
+    # the plugin if any spelling of it is on, rather than hide a working skill.
+    return any(on for key, on in state.items() if key.split("@", 1)[0] == name)
+
+
+def _plugin_id(cmd_dir: Path) -> tuple:
+    """(plugin, marketplace) for a .../commands dir under ~/.claude/plugins."""
+    marketplace = ""
+    parts = cmd_dir.parts
+    if "marketplaces" in parts:
+        idx = parts.index("marketplaces")
+        if idx + 1 < len(parts):
+            marketplace = parts[idx + 1]
+    return cmd_dir.parent.name, marketplace
+
+
 def get_skills(working_dir: str = None) -> list:
     """Return list of available Claude Code skills from ~/.claude/commands/ and plugins.
 
     Each item: {name, description, argument_hint, source}
     Skills are invoked as /skill-name [args] when passed as a task prompt to Claude Code.
     Only relevant for providers with supports_skills=True (claude, claude-z).
+
+    Resolution order is specific-first — local (the task's own repository), then
+    user, then plugin — because a name collision must be won by the skill the
+    task would actually run, not by whichever directory got scanned first.
+    Commands of plugins that are not enabled in Claude Code are left out: they
+    cannot be invoked the way this list says they can.
     """
     skills = []
     seen = set()
@@ -849,22 +928,28 @@ def get_skills(working_dir: str = None) -> list:
                 "source": source,
             })
 
+    # Project-local commands/skills — scanned first, so a project skill wins
+    # its own name over a user or plugin command spelled the same way.
+    if working_dir:
+        _add_from_dir(Path(working_dir) / ".claude" / "commands", "local")
+        _add_from_dir(Path(working_dir) / ".claude" / "skills", "local")
+
     # Global user commands/skills (~/.claude/commands/ and ~/.claude/skills/)
     _add_from_dir(Path.home() / ".claude" / "commands", "user")
     _add_from_dir(Path.home() / ".claude" / "skills", "user")
 
-    # Plugin commands — scan all directories named "commands" under ~/.claude/plugins/
+    # Plugin commands — scan all directories named "commands" under
+    # ~/.claude/plugins/, skipping plugins the user has not enabled.
     plugins_dir = Path.home() / ".claude" / "plugins"
     if plugins_dir.is_dir():
+        enabled = _enabled_plugins(working_dir)
         for cmd_dir in sorted(plugins_dir.rglob("commands")):
-            if cmd_dir.is_dir():
-                plugin_name = cmd_dir.parent.name
-                _add_from_dir(cmd_dir, f"plugin:{plugin_name}")
-
-    # Project-local commands/skills
-    if working_dir:
-        _add_from_dir(Path(working_dir) / ".claude" / "commands", "local")
-        _add_from_dir(Path(working_dir) / ".claude" / "skills", "local")
+            if not cmd_dir.is_dir():
+                continue
+            plugin_name, marketplace = _plugin_id(cmd_dir)
+            if not _plugin_enabled(enabled, plugin_name, marketplace):
+                continue
+            _add_from_dir(cmd_dir, f"plugin:{plugin_name}")
 
     return skills
 

--- a/promptpilot/static/index.html
+++ b/promptpilot/static/index.html
@@ -460,6 +460,17 @@
   .skill-name { font-family: var(--mono); font-size: 12px; color: var(--accent2); min-width: 120px; }
   .skill-arghint { font-size: 11px; color: var(--yellow); }
   .skill-desc { font-size: 11px; color: var(--text2); }
+  .skill-src {
+    font-size: 10px;
+    color: var(--text2);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 1px 5px;
+    margin-left: auto;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+  .skill-src.local { color: var(--accent2); border-color: var(--accent2); }
 </style>
 </head>
 <body>
@@ -1585,7 +1596,7 @@ async function toggleSkills() {
 
   const skills = skillsCache[cacheKey] || [];
   if (!skills.length) {
-    panel.innerHTML = '<div style="padding:8px 12px;color:var(--text2)">No skills found in ~/.claude/commands/ or plugins.</div>';
+    panel.innerHTML = '<div style="padding:8px 12px;color:var(--text2)">No skills found in ~/.claude/commands/, in this project\'s .claude/, or in enabled plugins. Commands of plugins not enabled in Claude Code are not listed.</div>';
     return;
   }
 
@@ -1594,8 +1605,15 @@ async function toggleSkills() {
       <span class="skill-name">/${esc(s.name)}</span>
       ${s.argument_hint ? `<span class="skill-arghint">[${esc(s.argument_hint)}]</span>` : ''}
       ${s.description ? `<span class="skill-desc">${esc(s.description)}</span>` : ''}
+      ${s.source ? `<span class="skill-src${s.source === 'local' ? ' local' : ''}" title="${escAttr(skillSourceHint(s.source))}">${esc(s.source === 'local' ? '📁 проект' : s.source)}</span>` : ''}
     </div>`
   ).join('');
+}
+
+function skillSourceHint(source) {
+  if (source === 'local') return 'Из .claude этого проекта — побеждает одноимённые user/plugin';
+  if (source === 'user') return 'Из ~/.claude — доступен в любой директории';
+  return 'Из включённого плагина Claude Code';
 }
 
 function selectSkill(name) {

--- a/tests/test_get_skills.py
+++ b/tests/test_get_skills.py
@@ -1,0 +1,128 @@
+"""get_skills(): resolution order and plugin enablement.
+
+Run: python3 -m unittest discover -s tests
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from promptpilot import config  # noqa: E402
+
+
+def _skill(dir_path: Path, name: str, description: str):
+    """Write a subdir-style skill: <dir>/<name>/SKILL.md with frontmatter."""
+    sub = dir_path / name
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+
+class GetSkillsTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.home = root / "home"
+        self.project = root / "project"
+        (self.home / ".claude" / "skills").mkdir(parents=True)
+        (self.project / ".claude" / "skills").mkdir(parents=True)
+        # ~/.claude/plugins/marketplaces/<marketplace>/plugins/<plugin>/commands
+        self.market = self.home / ".claude" / "plugins" / "marketplaces" / "mp"
+        patcher = mock.patch.object(Path, "home", classmethod(lambda cls: self.home))
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+    def _plugin(self, name: str, description: str, command: str = "shared"):
+        cmds = self.market / "plugins" / name / "commands"
+        cmds.mkdir(parents=True, exist_ok=True)
+        (cmds / f"{command}.md").write_text(
+            f"---\ndescription: {description}\n---\n\nbody\n", encoding="utf-8"
+        )
+
+    def _settings(self, enabled: dict, path: Path = None):
+        path = path or self.home / ".claude" / "settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"enabledPlugins": enabled}), encoding="utf-8")
+
+    def _by_name(self, working_dir=None):
+        return {s["name"]: s for s in config.get_skills(working_dir=working_dir)}
+
+    def test_project_skill_wins_over_user_and_plugin(self):
+        _skill(self.project / ".claude" / "skills", "shared", "from project")
+        _skill(self.home / ".claude" / "skills", "shared", "from user")
+        self._plugin("toolkit", "from plugin")
+        self._settings({"toolkit@mp": True})
+
+        found = self._by_name(str(self.project))
+        self.assertEqual(found["shared"]["source"], "local")
+        self.assertEqual(found["shared"]["description"], "from project")
+
+    def test_user_skill_wins_over_plugin(self):
+        _skill(self.home / ".claude" / "skills", "shared", "from user")
+        self._plugin("toolkit", "from plugin")
+        self._settings({"toolkit@mp": True})
+
+        found = self._by_name()
+        self.assertEqual(found["shared"]["source"], "user")
+
+    def test_plugin_commands_hidden_when_nothing_enabled(self):
+        """A marketplace clone alone enables nothing — and lists nothing."""
+        self._plugin("toolkit", "from plugin", command="review-pr")
+
+        self.assertEqual(self._by_name(), {})
+
+    def test_enabled_plugin_is_listed(self):
+        self._plugin("toolkit", "from plugin", command="review-pr")
+        self._settings({"toolkit@mp": True})
+
+        found = self._by_name()
+        self.assertEqual(found["review-pr"]["source"], "plugin:toolkit")
+
+    def test_disabled_plugin_is_not_listed(self):
+        self._plugin("toolkit", "from plugin", command="review-pr")
+        self._settings({"toolkit@mp": False})
+
+        self.assertEqual(self._by_name(), {})
+
+    def test_bare_plugin_name_key_is_honoured(self):
+        """Older Claude Code spelled the key without @marketplace."""
+        self._plugin("toolkit", "from plugin", command="review-pr")
+        self._settings({"toolkit": True})
+
+        self.assertIn("review-pr", self._by_name())
+
+    def test_project_settings_can_disable_a_user_enabled_plugin(self):
+        self._plugin("toolkit", "from plugin", command="review-pr")
+        self._settings({"toolkit@mp": True})
+        self._settings({"toolkit@mp": False},
+                       self.project / ".claude" / "settings.json")
+
+        self.assertEqual(self._by_name(str(self.project)), {})
+
+    def test_enabled_plugins_read_from_claude_json_projects_section(self):
+        self._plugin("toolkit", "from plugin", command="review-pr")
+        (self.home / ".claude.json").write_text(
+            json.dumps({"projects": {str(self.project): {"enabledPlugins": {"toolkit@mp": True}}}}),
+            encoding="utf-8",
+        )
+
+        self.assertIn("review-pr", self._by_name(str(self.project)))
+        self.assertEqual(self._by_name(), {})  # other directories: still off
+
+    def test_broken_settings_file_does_not_break_the_list(self):
+        _skill(self.home / ".claude" / "skills", "solo", "from user")
+        (self.home / ".claude" / "settings.json").write_text("{ not json", encoding="utf-8")
+
+        self.assertIn("solo", self._by_name())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`get_skills()` сканировал `user` → `plugin` → `local` и дедуплицировал по принципу «кто раньше, тот и занял имя». На машине с добавленным маркетплейсом (`~/.claude/plugins/marketplaces/claude-plugins-official`) это давало 32 записи, из которых почти все — команды **невключённых** плагинов: Claude Code их не покажет и не выполнит, а PromptPilot предлагал их кнопкой. Ключа `enabledPlugins` нет ни в `~/.claude/settings.json`, ни в `~/.claude.json` — то есть не включено ничего.

Второе следствие того же порядка: плагин заслонял проект. `.claude/skills/review-pr/SKILL.md` из `ivanarama/onebase` в списке не появлялся — имя занял `plugins/pr-review-toolkit/commands/review-pr.md` с описанием «Comprehensive PR review using specialized agents».

## Что сделано

- **Порядок разрешения `local` → `user` → `plugin`** (`config.py`): специфичное побеждает общее, дедуп `seen` остался прежним.
- **`enabledPlugins` уважается**. `_enabled_plugins()` читает `~/.claude/settings.json`, `~/.claude/settings.local.json`, `~/.claude.json` (включая секцию `projects[<working_dir>]`) и `.claude/settings.json` + `settings.local.json` самого проекта — в порядке возрастания специфичности, последний выигрывает. Ключ `<плагин>@<маркетплейс>`, поддержано и старое написание без маркетплейса; явный `false` выключает.
- **Источник виден человеку** (п. 3 заявки): в боте `📁` для проектных и `plugin:<имя>` курсивом, в Web UI — метка справа в строке скила с подсказкой при наведении. Поле `source` в API уже было, просто не показывалось.
- Пустые состояния теперь честные: и в боте, и в вебе сказано, что команды невключённых плагинов не перечисляются.
- README: раздел «Скилы Claude Code» описывает, что попадает в список и кто выигрывает имя.

## Почему так

**Отсутствие ключа = ничего не включено, а не «фильтровать нечем».** Это ровно то состояние, в котором маркетплейс просто добавлен, и оно самое частое. Обратный выбор («нет ключа — показываем всё») вернул бы исходную проблему целиком.

**Не по `installed_plugins.json`.** Claude Code синхронизирует его из `enabledPlugins` всех settings.json — то есть settings и есть источник правды, а производный файл может отсутствовать.

**Хвост на случай незнакомой раскладки каталогов.** Если маркетплейс не выводится из пути, плагин показывается, когда включено любое написание его имени: лучше лишняя строка в списке, чем молча исчезнувший рабочий скил.

## Проверки

- `python3 -m unittest discover -s tests` — 9 проверок, зелёные. Тестов в репозитории не было; взят stdlib `unittest`, новых зависимостей нет, в wheel каталог не попадает (`packages = ["promptpilot"]`).
  Покрыто: проект побеждает user и plugin; user побеждает plugin; клон маркетплейса без `enabledPlugins` не даёт ничего; включённый плагин виден; выключенный — нет; старое написание ключа; выключение на уровне проекта поверх включения у пользователя; секция `projects` из `~/.claude.json`; битый `settings.json` не роняет список.
- На этой машине до правки: 32 скила, почти все из невключённых плагинов. После: ровно 4 — этапы конвейера из `.claude/skills/` репозитория onebase, все с `source: local`.
- `GET /api/skills?provider=claude&workdir=…` через `fastapi.testclient` — 200 и те же 4 записи.
- `python3 -m compileall promptpilot` + импорт `config`/`api`/`bot`/`worker` — чисто.
- Web UI отрисован в headless-хроме на реальном `index.html` (Node в среде нет): панель скилов открывается, метка источника на месте, ошибок в консоли нет.

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)