### PR TITLE
fix(worker): очищать старую ошибку после успешного retry

### DIFF
--- a/promptpilot/db.py
+++ b/promptpilot/db.py
@@ -672,7 +672,9 @@ def mark_completed(task_id: int, result: str, exit_code: int = 0, model_used: st
     clear_note(task_id)
     with _connect() as conn:
         conn.execute(
-            "UPDATE tasks SET status = 'completed', result = ?, exit_code = ?, completed_at = ?, model_used = ?, session_id = COALESCE(?, session_id) WHERE id = ?",
+            "UPDATE tasks SET status = 'completed', result = ?, error = NULL, "
+            "next_run_at = NULL, exit_code = ?, completed_at = ?, model_used = ?, "
+            "session_id = COALESCE(?, session_id) WHERE id = ?",
             (result, exit_code, _now(), model_used, session_id, task_id),
         )
         _drop_cancel_flag(conn, task_id)

--- a/tests/test_schedule_series.py
+++ b/tests/test_schedule_series.py
@@ -217,6 +217,22 @@ def test_dependency_defer_returns_claimed_task_without_retry(isolated_db):
     assert deferred.error == "waiting for review"
 
 
+def test_successful_retry_clears_stale_error_and_backoff(isolated_db):
+    task = isolated_db.create_task(TaskCreate(prompt="Fix"))
+    claimed = isolated_db.get_next_runnable()
+    isolated_db.mark_rate_limited(
+        claimed.id, datetime.now(timezone.utc) - timedelta(minutes=1), "old failure",
+    )
+    retried = isolated_db.get_next_runnable()
+
+    isolated_db.mark_completed(retried.id, "done")
+
+    completed = isolated_db.get_task(task.id)
+    assert completed.status.value == "completed"
+    assert completed.error is None
+    assert completed.next_run_at is None
+
+
 def test_temporary_boost_returns_to_base_after_consecutive_empty(isolated_db):
     task = isolated_db.create_task(TaskCreate(prompt="Merge", recurrence="2h"))
     isolated_db.update_series(task.series_id, {


### PR DESCRIPTION
После успешного повтора задача больше не сохраняет ошибку и next_run_at от предыдущей rate-limited попытки.

Добавлен регрессионный тест. Проверка: 89 pytest passed.