### PR TITLE
fix(pipeline): откладывать MERGE только пока нужен REVIEW

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,11 @@ Worker публикует heartbeat в общей SQLite БД. Активный 
           "series_contains": "MyProject - MERGE",
           "dispatch_gate": {
             "skip_when_empty": true,
-            "defer_when_diagnostics_nonempty": ["review_candidates"],
+            "defer_when_diagnostics_match": [{
+              "field": "review_candidates",
+              "key": "stage",
+              "values": ["integration-review", "legacy-integration-review"]
+            }],
             "defer_for": "10m"
           }
         }
@@ -784,10 +788,12 @@ PromptPilot запускает её при каждом снимке и пока
 `dispatch_gate` тоже необязателен и настраивается у конкретного этапа. Перед
 запуском провайдера PromptPilot получает свежий снимок профиля. При
 `skip_when_empty` пустой запуск завершается как `ПУСТО`, не запуская LLM. Поле
-`defer_when_diagnostics_nonempty` задаёт зависимости через массивы из JSON
-`health_check`: в примере MERGE возвращается в pending на 10 минут, пока checker
-видит `review_candidates`. Это даёт автоматический порядок REVIEW → MERGE даже
-при более высоком приоритете MERGE и не расходует токены на ожидание. Если
+`defer_when_diagnostics_nonempty` задаёт простую зависимость от непустого массива
+в JSON `health_check`. Когда один массив содержит несколько состояний, используйте
+`defer_when_diagnostics_match`: в примере MERGE возвращается в pending только для
+элементов со stage `integration-review`/`legacy-integration-review`, но проходит
+для `integration-merge-ready`. Это даёт автоматический порядок REVIEW → MERGE
+даже при более высоком приоритете MERGE и не расходует токены на ожидание. Если
 профиль или checker сломан, gate fail-open: задача запускается обычным способом,
 чтобы ошибка наблюдаемости не остановила полезную работу.
 

--- a/promptpilot/pipeline_insights.py
+++ b/promptpilot/pipeline_insights.py
@@ -262,6 +262,27 @@ def dispatch_gate(task) -> dict | None:
                         "reason": f"ожидание этапа по diagnostics.{field} ({count})",
                         "profile_id": profile_id, "queue_id": queue_config["id"],
                     }
+            for rule in config.get("defer_when_diagnostics_match", []):
+                if not isinstance(rule, dict):
+                    continue
+                field = rule.get("field")
+                key = rule.get("key")
+                values = rule.get("values")
+                source = diagnostics.get(field) if isinstance(field, str) else None
+                if not isinstance(source, list) or not isinstance(key, str) or not isinstance(values, list):
+                    continue
+                allowed = set(values)
+                matches = [item for item in source
+                           if isinstance(item, dict) and item.get(key) in allowed]
+                if matches:
+                    return {
+                        "action": "defer",
+                        "defer_for": config.get("defer_for", "10m"),
+                        "reason": (
+                            f"ожидание этапа по diagnostics.{field}: "
+                            f"{key} совпал ({len(matches)})"),
+                        "profile_id": profile_id, "queue_id": queue_config["id"],
+                    }
             return None
     return None
 

--- a/tests/test_schedule_series.py
+++ b/tests/test_schedule_series.py
@@ -366,6 +366,45 @@ def test_dispatch_gate_defers_dependency_without_provider(isolated_db, monkeypat
     assert gate["defer_for"] == "7m"
     assert "review_candidates" in gate["reason"]
 
+
+def test_dispatch_gate_defers_only_matching_diagnostic_stages(isolated_db, monkeypatch):
+    task = isolated_db.create_task(TaskCreate(
+        prompt="ExampleProject - MERGE", recurrence="2h",
+    ))
+    profile = {
+        "title": "Example", "repository": "owner/example",
+        "queues": [{
+            "id": "merge", "title": "Merge", "query": "is:pr label:ship",
+            "series_contains": "ExampleProject - MERGE",
+            "dispatch_gate": {
+                "defer_when_diagnostics_match": [{
+                    "field": "review_candidates", "key": "stage",
+                    "values": ["integration-review", "legacy-integration-review"],
+                }],
+                "defer_for": "7m",
+            },
+        }],
+    }
+    monkeypatch.setattr(pipeline_insights, "_profiles", lambda: {"example": profile})
+    diagnostics = {"review_candidates": [
+        {"number": 42, "stage": "legacy-integration-review"},
+        {"number": 43, "stage": "integration-merge-ready"},
+    ]}
+    monkeypatch.setattr(pipeline_insights, "analyze", lambda *args, **kwargs: {
+        "queues": [{"id": "merge", "title": "Merge", "backlog": 2}],
+        "diagnostics": diagnostics,
+    })
+
+    gate = pipeline_insights.dispatch_gate(task)
+    assert gate["action"] == "defer"
+    assert "совпал (1)" in gate["reason"]
+
+    diagnostics["review_candidates"] = [
+        {"number": 43, "stage": "integration-merge-ready"},
+        {"number": 44, "stage": "integration-merge-recovery"},
+    ]
+    assert pipeline_insights.dispatch_gate(task) is None
+
 def test_pipeline_insights_history_is_profile_scoped_and_tracks_movement(isolated_db, monkeypatch):
     profile = {
         "title": "OtherProject pipeline", "repository": "owner/other",


### PR DESCRIPTION
MERGE dependency gates can now filter diagnostic arrays by an item field. This prevents `integration-merge-ready` from being mistaken for unfinished REVIEW while still deferring `integration-review` and `legacy-integration-review` without launching the provider.

Regression coverage includes a mixed diagnostic array and merge-ready pass-through. Проверка: 92 pytest passed.