### PR TITLE
fix(pipeline): pass configured GitHub CLI to nested health checks

### DIFF
--- a/promptpilot/pipeline_insights.py
+++ b/promptpilot/pipeline_insights.py
@@ -452,6 +452,10 @@ def _run_profile_health_check(profile: dict) -> dict | None:
     env = os.environ.copy()
     if env.get("PP_GH_EXE"):
         env.setdefault("GH_EXE", env["PP_GH_EXE"])
+        gh_dir = str(Path(env["PP_GH_EXE"]).parent)
+        path_parts = env.get("PATH", "").split(os.pathsep)
+        if gh_dir and gh_dir not in path_parts:
+            env["PATH"] = gh_dir + os.pathsep + env.get("PATH", "")
     try:
         run = subprocess.run(
             command, cwd=config.get("working_dir") or None, env=env,

--- a/promptpilot/project_pipeline.py
+++ b/promptpilot/project_pipeline.py
@@ -139,6 +139,10 @@ def run_health(config: dict) -> dict:
     env = os.environ.copy()
     if env.get("PP_GH_EXE"):
         env.setdefault("GH_EXE", env["PP_GH_EXE"])
+        gh_dir = str(Path(env["PP_GH_EXE"]).parent)
+        path_parts = env.get("PATH", "").split(os.pathsep)
+        if gh_dir and gh_dir not in path_parts:
+            env["PATH"] = gh_dir + os.pathsep + env.get("PATH", "")
     result = subprocess.run(command, capture_output=True, text=True, encoding="utf-8", errors="strict", env=env)
     if result.returncode not in (0, 1):
         raise PipelineError((result.stderr or result.stdout or "health command failed").strip())

--- a/tests/test_project_pipeline.py
+++ b/tests/test_project_pipeline.py
@@ -1,4 +1,6 @@
 import json
+import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -109,3 +111,20 @@ def test_capabilities_is_executor_neutral(tmp_path):
     }), encoding="utf-8")
     config = pp.load_config(str(config_path))
     assert pp.capabilities(config)["protocol"] == "promptpilot-pipelinectl-v1"
+
+
+def test_health_exposes_configured_gh_to_nested_checker(monkeypatch):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout='{"state":"green"}', stderr="")
+
+    gh = os.path.join("tools", "github", "gh.exe")
+    monkeypatch.setenv("PP_GH_EXE", gh)
+    monkeypatch.setenv("PATH", "existing")
+    monkeypatch.setattr(pp.subprocess, "run", fake_run)
+
+    assert pp.run_health({"health_command": ["project-health", "-json"]})["state"] == "green"
+    assert captured["env"]["GH_EXE"] == gh
+    assert captured["env"]["PATH"].split(os.pathsep)[0] == os.path.dirname(gh)

--- a/tests/test_schedule_series.py
+++ b/tests/test_schedule_series.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import os
 from types import SimpleNamespace
 
 from promptpilot.models import TaskCreate
@@ -53,6 +54,25 @@ def test_project_health_check_is_immediate_and_accepts_red_json(monkeypatch):
     assert calls[0]["timeout"] == 180
     assert health["state"] == "red"
     assert health["label"] == "нарушен инвариант"
+
+
+def test_profile_health_exposes_configured_gh_to_nested_checker(monkeypatch):
+    calls = []
+    gh = os.path.join("tools", "github", "gh.exe")
+    monkeypatch.setenv("PP_GH_EXE", gh)
+    monkeypatch.setenv("PATH", "existing")
+    monkeypatch.setattr(
+        pipeline_insights.subprocess, "run",
+        lambda *args, **kwargs: calls.append(kwargs) or SimpleNamespace(
+            returncode=0, stdout='{"state":"green","findings":[]}', stderr=""),
+    )
+
+    pipeline_insights._run_profile_health_check({
+        "health_check": {"command": ["project-health", "-json"]},
+    })
+
+    assert calls[0]["env"]["GH_EXE"] == gh
+    assert calls[0]["env"]["PATH"].split(os.pathsep)[0] == os.path.dirname(gh)
 
 
 def test_health_check_failure_is_not_reported_as_broken_invariant(monkeypatch):


### PR DESCRIPTION
## Что исправлено

PromptPilot теперь добавляет каталог настроенного `PP_GH_EXE` в `PATH` вложенных project health-check. Это нужно для Go/PowerShell-проверок, которые запускают команду `gh`, а не читают `GH_EXE` напрямую.

Изменение действует и для дашборда, и для deterministic `pipelinectl`.

## Проверка

- `104 passed`
- воспроизведение на PuT: вложенный health-check теперь находит GitHub CLI