### PR TITLE
fix(pipeline): keep content review lane moving

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,8 @@ Worker публикует heartbeat в общей SQLite БД. Активный 
           "query": "is:issue is:open label:ready-fix -label:in-work",
           "capacity": 1,
           "series_contains": "MyProject - FIX",
+          "backlog_diagnostic_field": "fix_candidates",
+          "wake_when": {"field": "fix_candidates"},
           "dispatch_gate": {
             "skip_when_empty": true
           }
@@ -755,9 +757,11 @@ Worker публикует heartbeat в общей SQLite БД. Активный 
         {
           "id": "review",
           "title": "Ревью",
-          "query": "is:pr is:open -label:reviewed",
+          "query": "is:pr is:open -label:ship -label:changes-requested -label:needs-decision -label:hold",
           "capacity": 2,
-          "series_contains": "MyProject - REVIEW"
+          "series_contains": "MyProject - REVIEW",
+          "backlog_diagnostic_field": "review_backlog",
+          "wake_when": {"field": "review_candidates"}
         },
         {
           "id": "merge",
@@ -765,6 +769,8 @@ Worker публикует heartbeat в общей SQLite БД. Активный 
           "query": "is:pr is:open label:ship",
           "capacity": 1,
           "series_contains": "MyProject - MERGE",
+          "backlog_diagnostic_field": "merge_candidates",
+          "wake_when": {"field": "merge_candidates"},
           "dispatch_gate": {
             "skip_when_empty": true,
             "defer_when_diagnostics_match": [{
@@ -818,6 +824,28 @@ PromptPilot запускает её при каждом снимке и пока
 даже при более высоком приоритете MERGE и не расходует токены на ожидание. Если
 профиль или checker сломан, gate fail-open: задача запускается обычным способом,
 чтобы ошибка наблюдаемости не остановила полезную работу.
+
+`wake_when` необязателен. Он указывает поле диагностики, которое означает, что
+этапу уже есть что делать. После любого полезного (`ГОТОВО`) запуска и при
+фоновом обновлении профиля PromptPilot переводит ближайший pending-запуск этой
+серии на «сейчас». Поэтому FIX → REVIEW и REVIEW → MERGE не ждут следующего
+периодического интервала. Можно добавить `key` и `values`, если готовность
+определяется только некоторыми состояниями элементов. При `ПУСТО`, паузе серии
+или пустом поле пробуждения нет.
+
+`backlog_diagnostic_field` заменяет приблизительный размер GitHub Search точным
+массивом из `health_check`. Это особенно важно для REVIEW: поисковый запрос
+намеренно не исключает stale-метку `reviewed`, а checker уже различает новый
+HEAD, актуально проверенный HEAD и интеграционный handoff. Для REVIEW используйте
+`review_backlog` (вся ожидающая работа), а `wake_when` оставьте на
+`review_candidates` (только исполняемая сейчас работа).
+
+Не исключайте `reviewed` из поискового запроса REVIEW: метка относится к старому
+HEAD и после нового push может остаться. Канонический `health_check` отличает
+актуальное ревью (`reviewed_waiting_ship`) от устаревшей метки и возвращает новый
+HEAD в `review_candidates`. Для двухполосной схемы он также публикует
+`content_review_candidates`, `integration_owner` и `merge_candidates`:
+single-flight сериализует интеграцию, но не останавливает содержательные ревью.
 
 #### Детерминированный `pipelinectl` и fallback на скилл
 

--- a/promptpilot/pipeline_insights.py
+++ b/promptpilot/pipeline_insights.py
@@ -441,6 +441,58 @@ def _matching_queue(task) -> tuple[str, dict, dict] | None:
     return None
 
 
+def _diagnostic_match_count(diagnostics: dict, condition: dict) -> int:
+    field = condition.get("field")
+    if not isinstance(field, str):
+        return 0
+    value = diagnostics.get(field)
+    key, values = condition.get("key"), condition.get("values")
+    if key is None and values is None:
+        if isinstance(value, (list, dict, str)):
+            return len(value)
+        return int(bool(value))
+    if not isinstance(key, str) or not isinstance(values, list):
+        return 0
+    allowed = set(values)
+    if isinstance(value, dict):
+        return int(value.get(key) in allowed)
+    if isinstance(value, list):
+        return sum(1 for item in value if isinstance(item, dict) and item.get(key) in allowed)
+    return 0
+
+
+def _wake_ready_queues(profile: dict, data: dict, series: list[dict]) -> list[str]:
+    """Wake configured queues whose project-owned diagnostics say work is ready."""
+    diagnostics = data.get("diagnostics") or {}
+    woken = []
+    for queue in profile.get("queues", []):
+        condition = queue.get("wake_when")
+        marker = str(queue.get("series_contains") or "").lower()
+        if not isinstance(condition, dict) or not marker:
+            continue
+        if _diagnostic_match_count(diagnostics, condition) == 0:
+            continue
+        target = next((item for item in series
+                       if marker in str(item.get("title", "")).lower()
+                       and not item.get("ended") and not item.get("paused")), None)
+        if target and db.series_action(int(target["id"]), "run_now"):
+            woken.append(str(queue.get("id")))
+    return woken
+
+
+def after_task_completed(task, verdict: str | None) -> list[str]:
+    """Immediately advance ready pipeline stages after a productive run."""
+    if str(verdict or "").upper() != "ГОТОВО":
+        return []
+    matched = _matching_queue(task)
+    if matched is None:
+        return []
+    profile_id, profile, _queue = matched
+    series = db.list_series()
+    data = analyze(profile_id, series, use_cache=False)
+    return _wake_ready_queues(profile, data, series)
+
+
 def _expanded_command(values, stage: str) -> list[str] | None:
     command = values
     if not isinstance(command, list) or not command or not all(
@@ -805,6 +857,7 @@ def analyze(profile_id: str, series: list[dict], *, use_cache: bool = True) -> d
             return cached[1]
         profile = profiles[profile_id]
         priority_settings = _priority_settings(profile)
+        diagnostics = _run_profile_health_check(profile)
         target_hours = float(profile.get("target_clear_hours", 8))
         now = datetime.now(timezone.utc)
         queues = []
@@ -823,7 +876,16 @@ def analyze(profile_id: str, series: list[dict], *, use_cache: bool = True) -> d
             for search in searches:
                 for member in search["items"]:
                     members[member["key"]] = member
-                    all_items[member["key"]] = member
+            diagnostic_field = item.get("backlog_diagnostic_field")
+            diagnostic_items = (diagnostics or {}).get(diagnostic_field) if isinstance(diagnostic_field, str) else None
+            if isinstance(diagnostic_items, list):
+                allowed_numbers = {int(candidate["number"]) for candidate in diagnostic_items
+                                   if isinstance(candidate, dict) and str(candidate.get("number", "")).isdigit()}
+                backlog = len(diagnostic_items)
+                members = {key: member for key, member in members.items()
+                           if str(member.get("number", "")).isdigit()
+                           and int(member["number"]) in allowed_numbers}
+            all_items.update(members)
             capacity = max(1, int(item.get("capacity", 1)))
             matching = next((s for s in series
                              if item.get("series_contains", "").lower() in s["title"].lower()), None)
@@ -889,7 +951,6 @@ def analyze(profile_id: str, series: list[dict], *, use_cache: bool = True) -> d
                 [queue["series_id"]] if queue.get("series_id") else [],
                 now - timedelta(hours=5),
             )
-        diagnostics = _run_profile_health_check(profile)
         runtime = _pipeline_runtime(matching_series, now)
         result = {
             "profile_id": profile_id, "title": profile["title"],
@@ -920,8 +981,9 @@ def sample_active_profiles(series: list[dict]) -> dict[str, str]:
         if not _profile_active(profile, series):
             continue
         try:
-            analyze(profile_id, series, use_cache=False)
-            outcomes[profile_id] = "ok"
+            data = analyze(profile_id, series, use_cache=False)
+            woken = _wake_ready_queues(profile, data, series)
+            outcomes[profile_id] = "ok" + (f"; woken={','.join(woken)}" if woken else "")
         except Exception as exc:  # one external repository must not stop the sampler
             outcomes[profile_id] = str(exc)
     return outcomes

--- a/promptpilot/project_pipeline.py
+++ b/promptpilot/project_pipeline.py
@@ -65,6 +65,13 @@ def digest(value) -> str:
     return hashlib.sha256(canonical(value)).hexdigest()
 
 
+def content_review_digest(snapshot: dict) -> str:
+    """Bind an audit to PR content without invalidating it on a normal base advance."""
+    stable = dict(snapshot)
+    stable.pop("baseRefOid", None)
+    return digest(stable)
+
+
 def encode_lease(value: dict) -> str:
     return base64.urlsafe_b64encode(canonical(value)).decode("ascii").rstrip("=")
 
@@ -369,8 +376,20 @@ def ensure_identity(gh: GitHub, config: dict) -> None:
 
 def capabilities(config: dict) -> dict:
     return {"protocol": "promptpilot-pipelinectl-v1", "repository": config["repository"],
-            "stages": {"review": "ordinary", "merge": "clean-ordinary"},
+            "stages": {"review": "content-or-integration", "merge": "clean-ordinary"},
             "fallback": "repository skill"}
+
+
+def review_empty_reason(health: dict) -> str:
+    owner = health.get("integration_owner")
+    if isinstance(owner, dict) and owner.get("number"):
+        return (f"содержательная очередь пуста; интеграционный владелец "
+                f"#{owner['number']} находится на этапе {owner.get('stage', 'unknown')}")
+    waiting = health.get("reviewed_waiting_ship") or []
+    if waiting:
+        numbers = ", ".join(f"#{item.get('number')}" for item in waiting[:5])
+        return f"содержательная очередь пуста; ждут решения ship: {numbers}"
+    return str(health.get("summary") or "содержательная очередь ревью пуста")
 
 
 def next_review(gh: GitHub, config: dict) -> dict:
@@ -379,9 +398,9 @@ def next_review(gh: GitHub, config: dict) -> dict:
         return {"action": "fallback", "reason": "health check is red"}
     candidates = health.get("review_candidates") or []
     if not candidates:
-        return {"action": "empty", "verdict": "ПУСТО", "reason": "review queue is empty"}
+        return {"action": "empty", "verdict": "ПУСТО", "reason": review_empty_reason(health)}
     item = candidates[0]
-    if item.get("stage") != "review" or any(f.get("code") == "single_flight_barrier" for f in health.get("findings", [])):
+    if item.get("stage") != "review":
         return {"action": "fallback", "reason": "integration/base-sync state requires the full skill"}
     if int(item.get("review_depth", 0)) >= 2:
         return {"action": "fallback", "reason": "third review round requires human-escalation rules"}
@@ -398,7 +417,7 @@ def next_review(gh: GitHub, config: dict) -> dict:
             return {"action": "fallback", "reason": "current epoch contains recovery/protocol state"}
     lease = {"version": 1, "stage": "review", "repository": config["repository"],
              "number": item["number"], "head": snapshot["headRefOid"],
-             "snapshot": digest(snapshot), "epoch": info["hash"],
+             "snapshot": content_review_digest(snapshot), "epoch": info["hash"],
              "anchor": info["anchor_id"], "depth": int(item.get("review_depth", 0))}
     return {"action": "audit", "target": item, "lease": encode_lease(lease),
             "inspect": [f"gh pr view {item['number']} --repo {config['repository']} --json title,body,headRefName,files,statusCheckRollup",
@@ -466,12 +485,11 @@ def complete_review(gh: GitHub, config: dict, lease_value: str, report_path: str
         raise PipelineError("health check became red")
     candidates = health.get("review_candidates") or []
     if (not candidates or int(candidates[0].get("number", 0)) != int(lease["number"])
-            or candidates[0].get("stage") != "review"
-            or any(item.get("code") == "single_flight_barrier" for item in health.get("findings", []))):
+            or candidates[0].get("stage") != "review"):
         raise PipelineError("global REVIEW allowlist changed; rerun next review")
     snapshot = stable_timeline(gh, config, int(lease["number"]))
     validate_common(snapshot, config, lease)
-    if digest(snapshot) != lease["snapshot"]:
+    if content_review_digest(snapshot) != lease["snapshot"]:
         raise PipelineError("lease is stale; rerun next review")
     info = review_gate(snapshot, config, lease)
     review = post_comment(gh, config, lease["number"], body)

--- a/promptpilot/static/index.html
+++ b/promptpilot/static/index.html
@@ -2526,7 +2526,7 @@ function aggregateDiagnosticFindings(findings) {
 
 function diagnosticFindingMessage(finding) {
   const messages = {
-    single_flight_barrier: 'Пока этот PR не завершит цикл REVIEW → MERGE, остальные остаются в очереди.',
+    single_flight_barrier: 'Интеграционная полоса занята этим PR; обычное содержательное ревью других PR продолжает работать.',
     legacy_ship_waiting_review_validation: 'Переход со старого формата: очередь безопасно перепроверит эти PR перед слиянием.',
     base_sync_base_advanced: 'Ветка main обновилась после подготовки PR; перед слиянием нужна повторная синхронизация.',
     health_check_failed: 'Сама проверка состояния не завершилась. Повторите обновление; это ещё не означает нарушение конвейера.',
@@ -2545,7 +2545,7 @@ function renderDiagnosticFinding(finding, data) {
   const rest = finding.prs.length > 5 ? ` и ещё ${finding.prs.length - 5}` : '';
   const prefix = finding.prs.length
     ? finding.code === 'single_flight_barrier'
-      ? `${queueTaskIsRunning(data, 'review') ? 'Сейчас на ревью' : 'Первый в очереди'}: ${shown}${rest} · `
+      ? `Интеграционный владелец: ${shown}${rest} · `
       : `PR ${shown}${rest} · `
     : '';
   return `<li class="${finding.severity === 'red' ? 'error-text' : ''}">${prefix}${esc(diagnosticFindingMessage(finding))}</li>`;
@@ -2555,11 +2555,22 @@ function diagnosticOverview(data) {
   const diagnostics = data.diagnostics || {};
   const parts = [];
   const review = diagnostics.review_candidates || [];
+  const reviewBacklog = diagnostics.review_backlog || review;
+  const content = diagnostics.content_review_candidates || [];
+  const waitingShip = diagnostics.reviewed_waiting_ship || [];
+  const merge = diagnostics.merge_candidates || [];
+  const owner = diagnostics.integration_owner;
   const fix = diagnostics.fix_candidates || [];
   const human = diagnostics.human_waiting || [];
   const findings = diagnostics.findings || [];
   const legacy = findings.filter(f => f.code === 'legacy_ship_waiting_review_validation').length;
-  if (review.length) parts.push(`${queueTaskIsRunning(data, 'review') ? 'сейчас на ревью' : 'следующий в очереди на ревью'}: #${review[0].number}`);
+  if (queueTaskIsRunning(data, 'review')) parts.push('REVIEW сейчас выполняется');
+  if (reviewBacklog.length) parts.push(`всего ждут REVIEW: ${reviewBacklog.length}`);
+  if (review.length) parts.push(`к REVIEW готовы: ${review.length} (следующий #${review[0].number})`);
+  if (content.length) parts.push(`содержательная очередь: ${content.length}`);
+  if (owner) parts.push(`интеграция: #${owner.number} · ${owner.stage}`);
+  if (waitingShip.length) parts.push(`прошли ревью, ждут ship: ${waitingShip.length}`);
+  if (merge.length) parts.push(`готовы к слиянию: ${merge.length}`);
   if (fix.length) parts.push(`готовы к исправлению: ${fix.length}`);
   if (human.length) parts.push(`ждут решения человека: ${human.length}`);
   if (legacy) parts.push(`переходят со старого формата: ${legacy}`);

--- a/promptpilot/worker.py
+++ b/promptpilot/worker.py
@@ -55,6 +55,20 @@ RETRY_REASON_ERR = {
 }
 
 
+def _notify_pipeline_completion(task, verdict: str | None) -> None:
+    if str(verdict or "").upper() != "ГОТОВО":
+        return
+    try:
+        from . import pipeline_insights
+        woken = pipeline_insights.after_task_completed(task, verdict)
+        if woken:
+            print(f"  -> Pipeline stages woken: {', '.join(woken)}", flush=True)
+    except Exception as exc:
+        # Completion is already durable; a dashboard/wakeup failure must not
+        # rewrite the successful task outcome. The periodic sampler retries it.
+        print(f"  !! pipeline wake-up unavailable for #{task.id}: {exc}", flush=True)
+
+
 def retry_reason(text: str, exit_code: int) -> Optional[str]:
     """Why the run must be requeued: RETRY_RATE_LIMIT, RETRY_OVERLOAD or None.
 
@@ -979,6 +993,12 @@ def execute_task(task):
             _recur_after_run(task)
         except Exception as exc:
             print(f"  !! не смог продлить расписание #{task.id}: {exc}", flush=True)
+        try:
+            fresh = db.get_task(task.id)
+            if fresh and fresh.status.value == "completed":
+                _notify_pipeline_completion(fresh, fresh.verdict)
+        except Exception as exc:
+            print(f"  !! pipeline wake-up after recurrence #{task.id}: {exc}", flush=True)
         try:
             workflows.sync_task(task.id)
             workflows.advance_linked_task(task.id)

--- a/tests/test_project_pipeline.py
+++ b/tests/test_project_pipeline.py
@@ -139,3 +139,44 @@ def test_health_exposes_configured_gh_to_nested_checker(monkeypatch):
     assert pp.run_health({"health_command": ["project-health", "-json"]})["state"] == "green"
     assert captured["env"]["GH_EXE"] == gh
     assert captured["env"]["PATH"].split(os.pathsep)[0] == os.path.dirname(gh)
+
+
+def test_content_review_digest_ignores_only_base_tip_movement():
+    before = snapshot()
+    after = dict(before, baseRefOid="c" * 40)
+    assert pp.content_review_digest(before) == pp.content_review_digest(after)
+
+    changed_head = dict(after, headRefOid="d" * 40)
+    assert pp.content_review_digest(before) != pp.content_review_digest(changed_head)
+
+    changed_timeline = dict(after, updatedAt="2026-01-02T00:00:00Z")
+    assert pp.content_review_digest(before) != pp.content_review_digest(changed_timeline)
+
+
+def test_content_review_stays_executable_while_integration_owner_waits_merge(monkeypatch):
+    health = {
+        "state": "yellow",
+        "review_candidates": [{"number": 42, "head": HEAD, "stage": "review", "review_depth": 0}],
+        "integration_owner": {"number": 10, "stage": "integration-merge-ready"},
+        "findings": [{"code": "single_flight_barrier"}],
+    }
+    monkeypatch.setattr(pp, "run_health", lambda _config: health)
+    monkeypatch.setattr(pp, "stable_timeline", lambda _gh, _config, _number: snapshot())
+
+    result = pp.next_review(object(), {
+        "repository": "owner/repo", "trusted_account": "owner", "base_branch": "main",
+    })
+    assert result["action"] == "audit"
+    assert result["target"]["number"] == 42
+
+
+def test_empty_review_reason_explains_waiting_state():
+    reason = pp.review_empty_reason({
+        "integration_owner": {"number": 10, "stage": "integration-merge-ready"},
+    })
+    assert "#10" in reason
+    assert "integration-merge-ready" in reason
+
+    reason = pp.review_empty_reason({"reviewed_waiting_ship": [{"number": 11}]})
+    assert "ship" in reason
+    assert "#11" in reason

--- a/tests/test_schedule_series.py
+++ b/tests/test_schedule_series.py
@@ -335,6 +335,38 @@ def test_pipeline_insights_exposes_actual_series_task_status(isolated_db, monkey
     assert review["task_status"] == "running"
 
 
+def test_pipeline_backlog_can_use_exact_project_diagnostics(isolated_db, monkeypatch):
+    profile = {
+        "title": "Example", "repository": "owner/example",
+        "health_check": {"command": ["health"]},
+        "queues": [{
+            "id": "review", "title": "Review", "capacity": 2,
+            "query": "is:pr", "series_contains": "REVIEW",
+            "backlog_diagnostic_field": "review_candidates",
+        }],
+    }
+    monkeypatch.setattr(pipeline_insights, "_profiles", lambda: {"example": profile})
+    monkeypatch.setattr(pipeline_insights, "_run_profile_health_check", lambda _profile: {
+        "state": "green", "review_candidates": [{"number": 2}], "findings": [],
+    })
+    monkeypatch.setattr(pipeline_insights, "_github_search", lambda _repo, _query: {
+        "count": 3, "membership_complete": True,
+        "items": [
+            {"key": f"pr:{number}", "kind": "pr", "number": number,
+             "title": f"PR {number}", "labels": [], "created_at": "2026-09-01T00:00:00Z"}
+            for number in (1, 2, 3)
+        ],
+    })
+    pipeline_insights._cache.clear()
+
+    result = pipeline_insights.analyze("example", [], use_cache=False)
+    review = result["queues"][0]
+    assert review["backlog"] == 1
+    assert [item["number"] for item in review["items"]] == []  # priority UI is opt-in
+    snapshot = isolated_db.list_pipeline_snapshots("example")[-1]["payload"]
+    assert snapshot["queues"]["review"]["backlog"] == 1
+
+
 def test_pipeline_item_priority_manual_override_and_aging():
     settings = pipeline_insights._priority_settings({"priority_control": {"aging_hours": 24}})
     now = datetime(2026, 9, 2, tzinfo=timezone.utc)
@@ -471,6 +503,92 @@ def test_dispatch_gate_defers_only_matching_diagnostic_stages(isolated_db, monke
         {"number": 44, "stage": "integration-merge-recovery"},
     ]
     assert pipeline_insights.dispatch_gate(task) is None
+
+
+def test_productive_completion_wakes_every_ready_stage(monkeypatch):
+    profile = {
+        "title": "Example", "repository": "owner/example",
+        "queues": [
+            {"id": "fix", "series_contains": "Example - FIX"},
+            {"id": "review", "series_contains": "Example - REVIEW",
+             "wake_when": {"field": "review_candidates"}},
+            {"id": "merge", "series_contains": "Example - MERGE",
+             "wake_when": {"field": "integration_owner", "key": "stage",
+                           "values": ["integration-merge-ready"]}},
+        ],
+    }
+    series = [
+        {"id": 7, "title": "Example - REVIEW", "paused": False, "ended": False},
+        {"id": 8, "title": "Example - MERGE", "paused": False, "ended": False},
+    ]
+    monkeypatch.setattr(pipeline_insights, "_profiles", lambda: {"example": profile})
+    monkeypatch.setattr(pipeline_insights.db, "list_series", lambda: series)
+    monkeypatch.setattr(pipeline_insights, "analyze", lambda *args, **kwargs: {
+        "diagnostics": {
+            "review_candidates": [{"number": 42}],
+            "integration_owner": {"number": 10, "stage": "integration-merge-ready"},
+        },
+    })
+    calls = []
+    monkeypatch.setattr(
+        pipeline_insights.db, "series_action",
+        lambda series_id, action: calls.append((series_id, action)) or True,
+    )
+    task = SimpleNamespace(series_id=1, series_title="Example - FIX", prompt="Example - FIX")
+
+    assert pipeline_insights.after_task_completed(task, "ГОТОВО") == ["review", "merge"]
+    assert calls == [(7, "run_now"), (8, "run_now")]
+
+
+def test_wakeup_skips_empty_paused_and_nonproductive_runs(monkeypatch):
+    profile = {
+        "title": "Example", "repository": "owner/example",
+        "queues": [
+            {"id": "fix", "series_contains": "Example - FIX"},
+            {"id": "review", "series_contains": "Example - REVIEW",
+             "wake_when": {"field": "review_candidates"}},
+            {"id": "merge", "series_contains": "Example - MERGE",
+             "wake_when": {"field": "merge_candidates"}},
+        ],
+    }
+    series = [
+        {"id": 7, "title": "Example - REVIEW", "paused": True, "ended": False},
+        {"id": 8, "title": "Example - MERGE", "paused": False, "ended": False},
+    ]
+    monkeypatch.setattr(pipeline_insights, "_profiles", lambda: {"example": profile})
+    monkeypatch.setattr(pipeline_insights.db, "list_series", lambda: series)
+    monkeypatch.setattr(pipeline_insights, "analyze", lambda *args, **kwargs: {
+        "diagnostics": {"review_candidates": [{"number": 42}], "merge_candidates": []},
+    })
+    calls = []
+    monkeypatch.setattr(
+        pipeline_insights.db, "series_action",
+        lambda series_id, action: calls.append((series_id, action)) or True,
+    )
+    task = SimpleNamespace(series_id=1, series_title="Example - FIX", prompt="Example - FIX")
+
+    assert pipeline_insights.after_task_completed(task, "ПУСТО") == []
+    assert pipeline_insights.after_task_completed(task, "ГОТОВО") == []
+    assert calls == []
+
+
+def test_worker_wakes_pipeline_only_after_next_recurrence_exists(monkeypatch):
+    from promptpilot import workflows
+
+    events = []
+    task = SimpleNamespace(id=42)
+    fresh = SimpleNamespace(id=42, status=SimpleNamespace(value="completed"), verdict="ГОТОВО")
+    monkeypatch.setattr(worker, "_execute_task_inner", lambda _task: events.append("execute"))
+    monkeypatch.setattr(worker, "_recur_after_run", lambda _task: events.append("recur"))
+    monkeypatch.setattr(worker, "_notify_pipeline_completion",
+                        lambda _task, _verdict: events.append("wake"))
+    monkeypatch.setattr(worker.db, "get_task", lambda _task_id: fresh)
+    monkeypatch.setattr(workflows, "sync_task", lambda _task_id: None)
+    monkeypatch.setattr(workflows, "advance_linked_task", lambda _task_id: None)
+
+    worker.execute_task(task)
+
+    assert events == ["execute", "recur", "wake"]
 
 
 def test_pipeline_execution_auto_uses_tool_when_available(isolated_db, monkeypatch, tmp_path):

--- a/tests/test_workflow_api_cli.py
+++ b/tests/test_workflow_api_cli.py
@@ -111,8 +111,9 @@ def test_schedule_ui_exposes_durable_series_controls():
     assert "Переход со старого формата" in html
     assert "Состояние очереди" in html
     assert "queueTaskIsRunning(data, 'review')" in html
-    assert "Первый в очереди" in html
-    assert "Сейчас на ревью" in html
+    assert "Интеграционный владелец" in html
+    assert "REVIEW сейчас выполняется" in html
+    assert "всего ждут REVIEW" in html
     assert "diagnosticBadgeLabel" in html
     assert "это ещё не означает нарушение конвейера" in html
     assert "Текущая проверка" not in html


### PR DESCRIPTION
## Что изменено
- содержательное ревью не блокируется владельцем интеграционной полосы, который ждёт MERGE/recovery
- lease содержательного ревью переживает обычное движение base tip, но не новый HEAD/timeline
- точный backlog берётся из project health, stale `reviewed` больше не скрывает новый HEAD
- готовые этапы пробуждаются без ожидания следующего интервала
- дашборд отдельно показывает backlog, исполняемую очередь, integration owner, waiting ship и merge-ready

## Проверка
- `pytest -q`: 117 passed