### PR TITLE
fix: make Windows build bootstrap reliable

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -8,11 +8,25 @@ $ErrorActionPreference = "Stop"
 
 Write-Host "=== PromptPilot Build ===" -ForegroundColor Cyan
 
-# Install pyinstaller if missing
-python -m PyInstaller --version 2>$null | Out-Null
-if ($LASTEXITCODE -ne 0) {
+$python = "python"
+if (Test-Path -LiteralPath "$PSScriptRoot\.venv\Scripts\python.exe" -PathType Leaf) {
+    $python = "$PSScriptRoot\.venv\Scripts\python.exe"
+}
+Write-Host "Using: $python" -ForegroundColor DarkGray
+
+# Install pyinstaller if missing. Windows PowerShell turns redirected native
+# stderr into an ErrorRecord, so probe it without the script-wide Stop policy.
+$savedErrorActionPreference = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
+& $python -m PyInstaller --version 2>$null | Out-Null
+$pyInstallerMissing = $LASTEXITCODE -ne 0
+$ErrorActionPreference = $savedErrorActionPreference
+if ($pyInstallerMissing) {
     Write-Host "Installing PyInstaller..." -ForegroundColor Yellow
-    python -m pip install pyinstaller
+    & $python -m pip install pyinstaller
+    if ($LASTEXITCODE -ne 0) {
+        throw "Cannot install PyInstaller."
+    }
 }
 
 # Clean previous build
@@ -22,10 +36,10 @@ if (Test-Path build) { Remove-Item build -Recurse -Force }
 # Build
 if ($Debug) {
     Write-Host "Building pp.exe (debug)..." -ForegroundColor Yellow
-    python -m PyInstaller pp.spec --clean --debug all
+    & $python -m PyInstaller pp.spec --clean --debug all
 } else {
     Write-Host "Building pp.exe..." -ForegroundColor Yellow
-    python -m PyInstaller pp.spec --clean
+    & $python -m PyInstaller pp.spec --clean
 }
 
 if (Test-Path "dist\pp.exe") {

--- a/promptpilot/cli.py
+++ b/promptpilot/cli.py
@@ -882,6 +882,18 @@ def worker():
     run_worker()
 
 
+@cli.command(
+    "pipelinectl",
+    hidden=True,
+    context_settings={"ignore_unknown_options": True, "allow_extra_args": True},
+)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def pipelinectl(args):
+    """Run the bundled project pipeline adapter."""
+    from .project_pipeline import run
+    raise SystemExit(run(list(args)))
+
+
 @cli.command()
 def bot():
     """Start the Telegram bot (requires PP_TG_TOKEN env var)."""

--- a/promptpilot/pipeline_insights.py
+++ b/promptpilot/pipeline_insights.py
@@ -498,10 +498,17 @@ def _expanded_command(values, stage: str) -> list[str] | None:
     if not isinstance(command, list) or not command or not all(
             isinstance(value, str) and value for value in command):
         return None
-    return [
+    expanded = [
         value.replace("{python}", sys.executable).replace("{stage}", stage)
         for value in command
     ]
+    # In a PyInstaller bundle sys.executable is pp.exe, not a Python
+    # interpreter. Keep existing portable profile commands working by routing
+    # the bundled project adapter through pp's hidden pipelinectl command.
+    if (getattr(sys, "frozen", False) and len(expanded) >= 3 and
+            expanded[:3] == [sys.executable, "-m", "promptpilot.project_pipeline"]):
+        return [sys.executable, "pipelinectl", *expanded[3:]]
+    return expanded
 
 
 def _tool_command(execution: dict, stage: str) -> list[str] | None:

--- a/tests/test_schedule_series.py
+++ b/tests/test_schedule_series.py
@@ -624,6 +624,21 @@ def test_pipeline_execution_auto_uses_tool_when_available(isolated_db, monkeypat
     assert "/review-queue" in route["prompt"]
 
 
+def test_bundled_pipeline_command_routes_through_pp_cli(monkeypatch):
+    monkeypatch.setattr(pipeline_insights.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(pipeline_insights.sys, "executable", "C:\\PromptPilot\\pp.exe")
+
+    command = pipeline_insights._expanded_command([
+        "{python}", "-m", "promptpilot.project_pipeline",
+        "--config", "pipelinectl.json", "next", "{stage}",
+    ], "review")
+
+    assert command == [
+        "C:\\PromptPilot\\pp.exe", "pipelinectl",
+        "--config", "pipelinectl.json", "next", "review",
+    ]
+
+
 def test_pipeline_execution_empty_completes_without_provider(isolated_db, monkeypatch, tmp_path):
     helper = tmp_path / "pipelinectl.py"
     helper.write_text(


### PR DESCRIPTION
## Summary
- prefer the repository virtualenv when building the standalone executable
- allow the missing-PyInstaller probe to reach its install fallback under Windows PowerShell
- fail explicitly when dependency installation fails

## Verification
- exercised the missing-PyInstaller path
- built a 27.3 MB standalone executable with runtime dependencies discovered
- ran `dist\\pp.exe --help` successfully