### PR TITLE
feat: support maintenance plan handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,9 +743,24 @@ Worker публикует heartbeat в общей SQLite БД. Активный 
       },
       "queues": [
         {
+          "id": "plan",
+          "title": "Планы",
+          "query": "is:issue is:open label:plan-needed label:approved -label:hold -label:manual -label:plan-in-review",
+          "capacity": 1,
+          "series_contains": "MyProject - PLAN",
+          "backlog_diagnostic_field": "plan_candidates",
+          "wake_when": {"field": "plan_candidates"},
+          "dispatch_gate": {
+            "skip_when_empty": true
+          }
+        },
+        {
           "id": "fix",
           "title": "Исправления",
-          "query": "is:issue is:open label:ready-fix -label:in-work",
+          "queries": [
+            "is:issue is:open label:ready-fix -label:in-work -label:needs-decision -label:plan-needed -label:plan-in-review -label:hold -label:manual",
+            "is:issue is:open label:approved -label:in-work -label:plan-needed -label:plan-in-review -label:hold -label:manual"
+          ],
           "capacity": 1,
           "series_contains": "MyProject - FIX",
           "backlog_diagnostic_field": "fix_candidates",
@@ -803,6 +818,13 @@ P2, question — P3. Каждые `aging_hours` ожидания эффекти�
 правила: PromptPilot управляет метками и показывает порядок, но не подменяет
 безопасный выбор внутри репозитория. Проверка `trusted_account` не даёт случайно
 менять приоритет под другой учётной записью GitHub CLI.
+
+Если выбранное решение требует сначала архитектурного плана, FIX должен
+передать issue меткой `plan-needed`, сохранив человеческий `approved`. Отдельная
+серия PLAN создаёт PR только с плановым документом и переводит issue в
+`plan-in-review`; такой PR проходит обычные REVIEW, человеческий `ship` и MERGE.
+После merge проектный handoff снимает `plan-in-review` и возвращает issue в FIX.
+Так «сначала план» является исполняемым этапом, а не тупиком `needs-decision`.
 
 В workflow со sticky-разрешением метка `ship` означает «слить этот точный HEAD,
 когда его REVIEW успешно завершится». Она не исключает PR из первой review-
@@ -940,7 +962,7 @@ lease от модели не зависят.
 всю цепочку из шаблона» пока нет: этапы создаются как повторяющиеся задачи, а
 потом собираются профилем. Это важное отличие от Workflow-оркестратора:
 workflow ведёт конечную разработку «исполнитель → аудитор → исправление», а
-расписание обслуживает бесконечные дежурные очереди TRIAGE/FIX/REVIEW/MERGE.
+расписание обслуживает бесконечные дежурные очереди TRIAGE/PLAN/FIX/REVIEW/MERGE.
 
 Серия без запланированного вхождения помечается **«оборвана»** — она сама не
 продолжится. Раньше в это состояние приводило любое падение: следующее

--- a/promptpilot/project_pipeline.py
+++ b/promptpilot/project_pipeline.py
@@ -26,6 +26,7 @@ COMPLETE = re.compile(r"^<!-- pp:head-reviewed ([0-9a-f]{40}) review-comment=([0
 OVERRIDE = re.compile(r"(?m)^pp:review-again$")
 BASE_SYNC = re.compile(r"(?m)^<!-- pp:base-sync-(?:intent|done) ")
 LINKED = re.compile(r"(?i)\b(?:fix(?:e[sd])?|close[sd]?|resolve[sd]?)\s+#([0-9]+)")
+PLAN_LINK = re.compile(r"(?m)^Plan-Issue: #([0-9]+)\r?\nPlan-Path: (Plans/[^/\r\n]+\.md)$")
 
 TIMELINE_QUERY = r"""
 query($owner:String!,$name:String!,$number:Int!,$cursor:String){
@@ -393,6 +394,30 @@ def add_label(gh: GitHub, config: dict, number: int, label: str) -> None:
         raise PipelineError(f"label {label} was not confirmed")
 
 
+def remove_label(gh: GitHub, config: dict, number: int, label: str) -> None:
+    gh.run("api", "--method", "DELETE",
+           f"repos/{config['repository']}/issues/{number}/labels/{label}", allow=(0, 1))
+
+
+def finish_plan_handoff(gh: GitHub, config: dict, pr_number: int, body: str) -> dict | None:
+    """Return an issue to FIX after its reviewed plan PR was merged."""
+    match = PLAN_LINK.search(body or "")
+    if not match:
+        return None
+    issue_number, plan_path = int(match.group(1)), match.group(2)
+    issue = gh.json("api", f"repos/{config['repository']}/issues/{issue_number}")
+    labels = {item.get("name") for item in issue.get("labels", [])}
+    if issue.get("state") != "open" or "approved" not in labels or "plan-in-review" not in labels:
+        raise PipelineError(f"plan issue #{issue_number} is not in the approved plan-in-review state")
+    marker = (f"План `{plan_path}` влит через PR #{pr_number}; заявка возвращена в FIX.\n"
+              f"<!-- pp:plan-ready issue={issue_number} pr={pr_number} path={plan_path} -->")
+    post_comment(gh, config, issue_number, marker)
+    add_label(gh, config, issue_number, "ready-fix")
+    remove_label(gh, config, issue_number, "plan-in-review")
+    remove_label(gh, config, issue_number, "needs-decision")
+    return {"issue": issue_number, "path": plan_path}
+
+
 def ensure_identity(gh: GitHub, config: dict) -> None:
     identity = gh.json("api", "user")
     if identity.get("login") != config["trusted_account"]:
@@ -674,8 +699,11 @@ def complete_merge(gh: GitHub, config: dict, lease_value: str) -> dict:
                         f"repos/{config['repository']}/issues/{issue}/labels/in-work", allow=(0, 1))
         if output is not None:
             removed.append(issue)
+    plan_ready = finish_plan_handoff(
+        gh, config, int(lease["number"]), status.get("body") or "")
     return {"action": "completed", "stage": "merge", "number": lease["number"],
-            "head": lease["head"], "merge_sha": result.get("sha"), "in_work_checked": removed}
+            "head": lease["head"], "merge_sha": result.get("sha"),
+            "in_work_checked": removed, "plan_ready": plan_ready}
 
 
 def run(argv=None) -> int:

--- a/promptpilot/static/index.html
+++ b/promptpilot/static/index.html
@@ -2575,11 +2575,13 @@ function diagnosticOverview(data) {
   const merge = diagnostics.merge_candidates || [];
   const mergeExecutable = diagnostics.merge_executable || [];
   const owner = diagnostics.integration_owner;
+  const plan = diagnostics.plan_candidates || [];
   const fix = diagnostics.fix_candidates || [];
   const human = diagnostics.human_waiting || [];
   const findings = diagnostics.findings || [];
   const legacy = findings.filter(f => f.code === 'legacy_ship_waiting_review_validation').length;
   if (queueTaskIsRunning(data, 'review')) parts.push('REVIEW сейчас выполняется');
+  if (queueTaskIsRunning(data, 'plan')) parts.push('PLAN сейчас выполняется');
   if (reviewBacklog.length) parts.push(`всего ждут REVIEW: ${reviewBacklog.length}`);
   if (review.length) parts.push(`к REVIEW готовы: ${review.length} (следующий #${review[0].number})`);
   if (content.length) parts.push(`содержательная очередь: ${content.length}`);
@@ -2587,6 +2589,7 @@ function diagnosticOverview(data) {
   if (waitingShip.length) parts.push(`прошли ревью, ждут ship: ${waitingShip.length}`);
   if (merge.length) parts.push(`всего ждут MERGE: ${merge.length}`);
   if (mergeExecutable.length) parts.push(`к MERGE готовы сейчас: ${mergeExecutable.length}`);
+  if (plan.length) parts.push(`нужно подготовить план: ${plan.length} (следующая #${plan[0].number})`);
   if (fix.length) parts.push(`готовы к исправлению: ${fix.length}`);
   if (human.length) parts.push(`ждут решения человека: ${human.length}`);
   if (legacy) parts.push(`переходят со старого формата: ${legacy}`);

--- a/tests/test_project_pipeline.py
+++ b/tests/test_project_pipeline.py
@@ -225,3 +225,64 @@ def test_empty_review_reason_explains_waiting_state():
     reason = pp.review_empty_reason({"reviewed_waiting_ship": [{"number": 11}]})
     assert "ship" in reason
     assert "#11" in reason
+
+
+def test_plan_handoff_returns_approved_issue_to_fix():
+    class FakeGitHub:
+        def __init__(self):
+            self.comments = []
+            self.added = []
+            self.removed = []
+
+        def json(self, *args, input_value=None):
+            path = args[1]
+            if path.endswith("/issues/1274"):
+                return {"state": "open", "labels": [
+                    {"name": "approved"}, {"name": "plan-in-review"},
+                    {"name": "needs-decision"},
+                ]}
+            if path.endswith("/issues/1274/comments"):
+                self.comments.append(input_value["body"])
+                return {"body": input_value["body"], "user": {"login": "owner"}}
+            if path.endswith("/issues/1274/labels"):
+                self.added.extend(input_value["labels"])
+                return [{"name": value} for value in input_value["labels"]]
+            raise AssertionError(path)
+
+        def run(self, *args, input_value=None, allow=(0,)):
+            self.removed.append(args[-1].rsplit("/", 1)[-1])
+            return ""
+
+    gh = FakeGitHub()
+    result = pp.finish_plan_handoff(gh, {
+        "repository": "owner/repo", "trusted_account": "owner",
+    }, 1400, "Summary\nPlan-Issue: #1274\nPlan-Path: Plans/159-undefined-values.md")
+
+    assert result == {"issue": 1274, "path": "Plans/159-undefined-values.md"}
+    assert gh.added == ["ready-fix"]
+    assert gh.removed == ["plan-in-review", "needs-decision"]
+    assert "pp:plan-ready issue=1274 pr=1400" in gh.comments[0]
+
+
+def test_plan_handoff_accepts_repository_native_unicode_filename():
+    class FakeGitHub:
+        def json(self, *args, input_value=None):
+            path = args[1]
+            if path.endswith("/issues/7"):
+                return {"state": "open", "labels": [
+                    {"name": "approved"}, {"name": "plan-in-review"},
+                ]}
+            if path.endswith("/issues/7/comments"):
+                return {"body": input_value["body"], "user": {"login": "owner"}}
+            if path.endswith("/issues/7/labels"):
+                return [{"name": value} for value in input_value["labels"]]
+            raise AssertionError(path)
+
+        def run(self, *args, input_value=None, allow=(0,)):
+            return ""
+
+    result = pp.finish_plan_handoff(FakeGitHub(), {
+        "repository": "owner/repo", "trusted_account": "owner",
+    }, 1401, "Plan-Issue: #7\nPlan-Path: Plans/7-план-исправления.md")
+
+    assert result == {"issue": 7, "path": "Plans/7-план-исправления.md"}

--- a/tests/test_workflow_api_cli.py
+++ b/tests/test_workflow_api_cli.py
@@ -117,6 +117,8 @@ def test_schedule_ui_exposes_durable_series_controls():
     assert "queueTaskIsRunning(data, 'review')" in html
     assert "Интеграционный владелец" in html
     assert "REVIEW сейчас выполняется" in html
+    assert "PLAN сейчас выполняется" in html
+    assert "нужно подготовить план" in html
     assert "всего ждут REVIEW" in html
     assert "diagnosticBadgeLabel" in html
     assert "это ещё не означает нарушение конвейера" in html


### PR DESCRIPTION
Adds a generic PLAN queue example and completes plan-to-FIX issue handoff after a reviewed plan PR merges. Includes regression tests. Tests: 126 passed.